### PR TITLE
ci: grant issues write permission to Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## 概要

`.github/workflows/claude.yml` の `issues` パーミッションを `read` から `write` に変更しました。

## 変更内容

- `.github/workflows/claude.yml`: `issues: read` → `issues: write`

この変更により、Claude Code Action が `@claude` メンションをトリガーとしてコメントやPRで呼び出された際に、GitHub Issues の作成・編集・管理ができるようになります。

## テスト

- ワークフローファイルの diff を目視確認済み（1行変更）
- CI/CD への影響なし

## 関連Issue

なし