### PR TITLE
feat(ci): fetch.ts の定期実行ワークフロー追加

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,0 +1,29 @@
+name: Fetch
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prisma generate --schema backend/migration/schema.prisma
+
+      - run: npx tsx backend/scripts/fetch.ts
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要

`backend/scripts/fetch.ts` を GitHub Actions で定期実行するためのワークフローファイル `.github/workflows/fetch.yml` を新規追加します。

## 変更内容

- `.github/workflows/fetch.yml` を新規作成
  - 30分おきの cron スケジュール（`*/30 * * * *`）で `backend/scripts/fetch.ts` を実行
  - `workflow_dispatch` による手動実行にも対応
  - 既存の `fetch-hn.yml` と同じ構成をベースに、実行スクリプトを `backend/scripts/fetch-hn.ts` → `backend/scripts/fetch.ts` に変更
  - 必要なシークレット: `DATABASE_URL`, `GEMINI_API_KEY`, `SLACK_WEBHOOK_URL`

## テスト

- GitHub Actions の「Run workflow」ボタンで手動実行し、`backend/scripts/fetch.ts` が正常に完了することを確認
- ジョブログで Prisma generate・fetch 処理が期待通りに動作していることを確認

## 関連Issue

なし