### PR TITLE
ci: add Prisma migrate workflow

### DIFF
--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -1,0 +1,37 @@
+name: Prisma Migrate Deploy
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "本番データベースにマイグレーションを実行します。実行する場合はチェックを入れてください。"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  migrate:
+    # PR マージ時、または手動実行で confirm が true の場合のみ実行
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run prisma migrate deploy
+        run: npx prisma migrate deploy --schema backend/migration/schema.prisma
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## 概要

本番データベースへの Prisma マイグレーションを安全に実行するための GitHub Actions ワークフローを追加します。

## 変更内容

- `.github/workflows/prisma-migrate.yml` を新規追加
  - **自動実行:** `main` ブランチへの PR がマージされた時に自動でマイグレーションを実行
  - **手動実行:** `workflow_dispatch` トリガーによる手動実行をサポート
  - **誤操作防止:** 手動実行時はチェックボックスによる確認（`confirm: true`）が必要
  - **実行条件:** PR マージ時、または手動実行で `confirm` が `true` の場合のみジョブを実行
  - **タイムアウト:** 10 分でジョブを打ち切り、無限待機を防止
  - **認証:** `DATABASE_URL` シークレットを使用して本番 DB に接続

## テスト

- ワークフローのトリガー条件（`if` 式）をレビューして、意図しない実行がないことを確認
- `DATABASE_URL` シークレットが GitHub リポジトリに設定済みであることを確認してから本番利用する

## 関連 Issue

なし