### PR TITLE
fix: ccmanager post_creation フック修正

### DIFF
--- a/.ccmanager.json
+++ b/.ccmanager.json
@@ -1,0 +1,37 @@
+{
+  "worktree": {
+    "autoDirectory": true,
+    "autoDirectoryPattern": "../{project}-{branch}",
+    "copySessionData": true,
+    "sortByLastSession": false,
+    "autoUseDefaultBranch": false
+  },
+  "statusHooks": {
+    "idle": {
+      "command": "",
+      "enabled": true
+    },
+    "busy": {
+      "command": "",
+      "enabled": true
+    },
+    "waiting_input": {
+      "command": "",
+      "enabled": true
+    },
+    "pending_auto_approval": {
+      "command": "",
+      "enabled": true
+    }
+  },
+  "worktreeHooks": {
+    "post_creation": {
+      "command": "cp ../shinbun/.env ./.env && cp ../shinbun/frontend/.env ./frontend/.env && cd backend && pnpm install && cd ../frontend && pnpm install",
+      "enabled": true
+    },
+    "pre_creation": {
+      "command": "export CONFLICT_GUARD_BASE_BRANCH=$CCMANAGER_BASE_BRANCH",
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## 概要

CCManager の worktree `post_creation` フックの設定を修正した。typo の修正と、backend・frontend 両方での依存関係インストールを追加している。

## 変更内容

- `.ccmanager.json` の `post_creation` フックを更新
  - `.env` コピー先パスの typo 修正 (`frontned` → `frontend`)
  - `backend` ディレクトリでの `pnpm install` 実行を追加
  - `frontend` ディレクトリでの `pnpm install` 実行を追加

## テスト

- CCManager で新規 worktree を作成し、`post_creation` フックが正常に実行されることを手動確認

## 関連Issue

なし