### PR TITLE
fix: migrate workflows to pnpm

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -24,13 +24,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
 
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
 
-      - run: npx prisma generate --schema backend/migration/schema.prisma
+      - run: pnpm exec prisma generate --schema backend/migration/schema.prisma
 
-      - run: npx tsx backend/scripts/fetch.ts
+      - run: pnpm exec tsx backend/scripts/fetch.ts

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -24,14 +24,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
 
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
 
       - name: Run prisma migrate deploy
-        run: npx prisma migrate deploy --schema backend/migration/schema.prisma
+        run: pnpm exec prisma migrate deploy --schema backend/migration/schema.prisma
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## 概要

`fetch.yml` と `prisma-migrate.yml` のワークフローを npm から pnpm に移行する。プロジェクト全体はすでに pnpm に移行済みだったが、これら2つのワークフローだけ npm のままになっており、`package-lock.json` が存在しないため `cache: npm` でエラーが発生していた。

参考: https://github.com/reibomaru/shinbun/actions/runs/22791282068/job/66118182008

## 変更内容

**`.github/workflows/fetch.yml`**
- `pnpm/action-setup@v4` ステップを追加
- `cache: npm` → `cache: pnpm`
- `npm ci` → `pnpm install --frozen-lockfile`
- `npx prisma generate` → `pnpm exec prisma generate`
- `npx tsx` → `pnpm exec tsx`

**`.github/workflows/prisma-migrate.yml`**
- `pnpm/action-setup@v4` ステップを追加
- `cache: npm` → `cache: pnpm`
- `npm ci` → `pnpm install --frozen-lockfile`
- `npx prisma migrate deploy` → `pnpm exec prisma migrate deploy`

## 補足

`lint.yml` と `test.yml` はすでに pnpm 対応済み。`claude.yml` と `claude-code-review.yml` は Node.js セットアップを使わないため変更不要。

## テスト

- GitHub Actions の `fetch` ワークフローおよび `prisma-migrate` ワークフローを手動実行して、pnpm キャッシュが正常に機能することを確認する

## 関連Issue

なし