### PR TITLE
fix(ci): pnpm version競合を修正

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
## Summary

- GitHub Actions の `pnpm/action-setup@v4` で明示的な `version: 10` 指定を削除
- `package.json` の `packageManager: pnpm@10.29.3` から自動検出させる

## 原因

`pnpm/action-setup@v4` は `version` と `packageManager` の両方が指定されているとエラーになる:
```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.29.3 in the package.json with the key "packageManager"
```

## Test plan

- [ ] GitHub Actions ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)