### PR TITLE
fix(prisma): Vercelランタイム用のbinaryTargetを修正

### DIFF
--- a/backend/migration/schema.prisma
+++ b/backend/migration/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["postgresqlExtensions"]
-  binaryTargets   = ["native", "linux-arm64-openssl-3.0.x"]
+  binaryTargets   = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary

- Prisma `binaryTargets` を `rhel-openssl-3.0.x` に変更
- GitHub Actions (ubuntu/debian) でビルドすると `native` = `debian-openssl-3.0.x` になるが、Vercel ランタイムは rhel 系のため `rhel-openssl-3.0.x` が必要

## Test plan

- [ ] GitHub Actions でビルド・デプロイ後、画面が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)