### PR TITLE
ci(archive): migrate to pnpm and Vercel CLI

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -18,19 +18,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
 
-      - run: npm ci
+      - run: pnpm install --frozen-lockfile
 
-      - run: npx prisma generate --schema backend/migration/schema.prisma
+      - run: pnpm exec prisma generate --schema backend/migration/schema.prisma
 
-      - run: npx tsx backend/scripts/archive.ts
+      - run: pnpm exec tsx backend/scripts/archive.ts
 
-      - name: Trigger Vercel rebuild
-        if: env.VERCEL_DEPLOY_HOOK != ''
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
         env:
-          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
-        run: curl -s -X POST "$VERCEL_DEPLOY_HOOK"
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 概要

`.github/workflows/archive.yml` のCI設定を他のワークフローと統一する。

## 変更内容

- **npm → pnpm への移行**
  - `actions/setup-node` のキャッシュを `npm` から `pnpm` に変更
  - `pnpm/action-setup@v4` を追加
  - `npm ci` → `pnpm install --frozen-lockfile` に変更
  - `npx prisma generate` → `pnpm exec prisma generate` に変更
  - `npx tsx` → `pnpm exec tsx` に変更
  - `fetch.yml` との統一が目的

- **Vercel Deploy Hook（curl）→ Vercel CLI（pull/build/deploy）への変更**
  - `secrets.VERCEL_DEPLOY_HOOK` を使った `curl` 呼び出しを削除
  - Vercel CLI を使った `vercel pull` / `vercel build --prod` / `vercel deploy --prebuilt --prod` の3ステップに変更
  - `vars.VERCEL_ORG_ID`、`vars.VERCEL_PROJECT_ID`、`secrets.VERCEL_TOKEN` を使用
  - `vercel-production.yml` との統一が目的

## テスト

- GitHub Actions のワークフロー構文は既存の `fetch.yml` / `vercel-production.yml` と同一パターンであることを目視確認
- 次回のアーカイブ実行時（毎週日曜 UTC 0:00）に動作確認予定

## 関連Issue

なし